### PR TITLE
feat: add Slack notifications for CI success and failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,3 +60,50 @@ jobs:
           DB_USERNAME: ${{ secrets.POSTGRES_USER }}
           DB_PASSWORD: ${{ secrets.POSTGRES_PASSWORD }}
           DATABASE_NAME: intel_stock_test
+```   # Notify Slack on Success
+      - name: Notify Slack on Success
+        if: success()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: success
+          fields: repo,commit,author,action
+          custom_payload: |
+            {
+              "attachments": [
+                {
+                  "fallback": "CI Build Passed",
+                  "color": "#36a64f",
+                  "pretext": "✅ **Build Succeeded**",
+                  "title": "Repository: ${{ github.repository }}",
+                  "text": "Branch: `${{ github.ref }}`\nCommit: `${{ github.sha }}`",
+                  "footer": "GitHub Actions",
+                  "ts": $(date +%s)
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+
+      # Notify Slack on Failure
+      - name: Notify Slack on Failure
+        if: failure()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: failure
+          fields: repo,commit,author,action
+          custom_payload: |
+            {
+              "attachments": [
+                {
+                  "fallback": "CI Build Failed",
+                  "color": "#e01e5a",
+                  "pretext": "❌ **Build Failed**",
+                  "title": "Repository: ${{ github.repository }}",
+                  "text": "Branch: `${{ github.ref }}`\nCommit: `${{ github.sha }}`",
+                  "footer": "GitHub Actions",
+                  "ts": $(date +%s)
+                }
+              ]
+            }
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions CI workflow to notify a Slack channel about the success or failure of the CI build. The most important changes are:

Notifications:

* [`.github/workflows/ci.yml`](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR63-R109): Added steps to notify Slack on success and failure of the CI build using the `8398a7/action-slack@v3` action. The notification includes details such as the repository, commit, author, action, branch, and commit SHA.