### PR TITLE
refactor: enhance authentication flow and error handling in AuthController and AuthService

### DIFF
--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,4 +1,8 @@
-import { BadRequestException, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { UsersService } from '../users/users.service';
 import { JwtService } from '@nestjs/jwt';
@@ -20,12 +24,12 @@ export class AuthService {
       throw new BadRequestException('User not found');
     }
     const isPasswordMatching = await bcrypt.compare(password, user.password);
-    if (user && !isPasswordMatching) {
+    if (user && isPasswordMatching) {
       const { password, ...result } = user;
       return result;
     }
 
-    return user;
+    throw new UnauthorizedException('Invalid credentials');
   }
 
   async validateOauthLogin(user: any, provider: string): Promise<any> {

--- a/src/auth/strategies/jwt.strategy.ts
+++ b/src/auth/strategies/jwt.strategy.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PassportStrategy } from '@nestjs/passport';
 import { ExtractJwt, Strategy } from 'passport-jwt';
-import { jwtConstants } from '../constants';
 import { ConfigService } from '@nestjs/config';
 
 @Injectable()
@@ -18,6 +17,6 @@ export class JwtStrategy extends PassportStrategy(Strategy) {
   }
 
   async validate(payload: any) {
-    return { userId: payload.sub, email: payload.email };
+    return { id: payload.sub, email: payload.email };
   }
 }

--- a/src/common/decorators/current-user.decorator.ts
+++ b/src/common/decorators/current-user.decorator.ts
@@ -1,0 +1,8 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+
+export const CurrentUser = createParamDecorator(
+  (data, ctx: ExecutionContext) => {
+    const request = ctx.switchToHttp().getRequest();
+    return request.user;
+  },
+);

--- a/src/main.ts
+++ b/src/main.ts
@@ -9,6 +9,14 @@ async function bootstrap() {
     .setTitle('IntelliStock API')
     .setDescription('API description')
     .setVersion('1.0')
+    .addBearerAuth(
+      {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+      'access-token',
+    )
     .build();
   const documentFactory = () =>
     SwaggerModule.createDocument(app, swaggerConfig);


### PR DESCRIPTION
This pull request includes significant updates to the `AuthController`, `AuthService`, and related tests to improve authentication handling and error management. The changes include adding new decorators, modifying existing methods, and updating test cases to reflect these changes.

Improvements to `AuthController` and `AuthService`:

* [`src/auth/auth.controller.ts`](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9L29-R34): Replaced the `login` method with the `signIn` method, which now takes both `req` and `CreateUserDto` as parameters. Added the `CurrentUser` decorator and `UnauthorizedException` handling to the `getProfile` method. [[1]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9L29-R34) [[2]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R63-R70)
* [`src/auth/auth.service.ts`](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cL23-R32): Updated the `signIn` method to throw `UnauthorizedException` for invalid credentials instead of returning the user object.

Enhancements to test cases:

* [`src/auth/auth.controller.spec.ts`](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR135-R139): Modified test cases to use the new `signIn` method and updated the `getProfile` test to check for `UnauthorizedException` when no user is provided. [[1]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fR135-R139) [[2]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL146-R155) [[3]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL155-R176) [[4]](diffhunk://#diff-a96ff31e6b1ab098b1190b7793357bafa606a24cff8b7404e726dec695601c9fL262-R253)

New decorator and additional imports:

* [`src/common/decorators/current-user.decorator.ts`](diffhunk://#diff-85d022727e346c3a9247f8dbfa5d75145999d4b80676d4d920a2fceb26f9742dR1-R8): Added a new `CurrentUser` decorator to extract the current user from the request.
* `src/auth/auth.controller.ts`, `src/auth/auth.service.ts`: Added necessary imports for `UnauthorizedException` and `CurrentUser` decorator. [[1]](diffhunk://#diff-37d3279a8a78f12b16e161930290bf0ef16b705cb8d225e1382f364702ecaaf9R10-R18) [[2]](diffhunk://#diff-aea62a4c305374791411369a46e8553d716a032a03bb48136176873887e3311cL1-R5)

Other changes:

* [`src/main.ts`](diffhunk://#diff-4fab5baaca5c14d2de62d8d2fceef376ddddcc8e9509d86cfa5643f51b89ce3dR12-R19): Added Bearer authentication configuration to the Swagger setup.
* [`src/auth/strategies/jwt.strategy.ts`](diffhunk://#diff-7b8cc64e52efca5638a1741d6988b2cfa29382b8ec7feab4be316c946555f8f8L21-R20): Updated the `validate` method to return `id` instead of `userId` in the JWT payload.